### PR TITLE
Add basic Oniro project introduction and build instructions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,13 @@ url: https://eclipse-oniro4openharmony.github.io
 
 aux_links:
   Template Repository: https://github.com/eclipse-oniro4openharmony/eclipse-oniro4openharmony.github.io
+
+# Makes Aux links open in a new tab. Default is false
+aux_links_new_tab: false
+
+# External navigation links
+nav_external_links:
+  - title: Oniro Legacy Documentation
+    url: https://oniroproject.readthedocs.io/
+    hide_icon: false
+    opens_in_new_tab: false

--- a/index.md
+++ b/index.md
@@ -1,52 +1,40 @@
 ---
-title: Eclipse Oniro4OpenHarmony
 layout: home
+title: Eclipse Oniro Project
+has_children: true
 ---
-## Eclipse Oniro4OpenHarmony Documentation
 
-Oniro is an Eclipse Foundation project focused on developing a distributed open source operating system platform that enables interoperability of devices, regardless of brand, make, or model. The platform is designed to be compatible with a broad range of embedded operating system environments, including OpenHarmony, an open source operating system specified and hosted by the OpenAtom Foundation. Managed as an Eclipse Foundation project and working group, Oniro benefits from the Eclipse Foundation's extensive experience in open source governance, along with an advanced IP compliance and licensing toolchain.
+# Welcome to Oniro Project documentation!
 
-Oniro provides the foundational fabric for a wide range of devices, both large and small, offering seamless interoperability, modularization, and a rich graphical user interface. It supports various global technologies and use cases across industries, including Consumer Electronics, Home Appliances, Industrial IoT devices, Smart Homes, and Multimedia.
+> *Oniro™ is a registered trademark of Eclipse Foundation.*
+>
+> *In 2023, the Oniro project underwent a significant transition. For those seeking information on the project's previous developments, including the state of the art [IP compliance toolchain](https://oniroproject.readthedocs.io/en/latest/releases/2.0/2.0.0/ip_compliance_note.html), please consult our [legacy documentation](https://oniroproject.readthedocs.io/).*
 
-----
+## About Oniro
+
+[Oniro](https://oniroproject.org/) is an open-source, vendor-neutral Operating System (OS) managed by the [Eclipse Foundation](https://www.eclipse.org/). It is built upon the foundational layers of [OpenHarmony](https://gitee.com/openharmony/docs), an open-source project incubated and operated by the [OpenAtom Foundation](https://www.openatom.org/). OpenHarmony is known for its distributed OS features that cater to a wide range of smart devices, regardless of their size. Oniro extends OpenHarmony code base with add-ons for the European and Global markets, such as [ReactNative](https://reactnative.dev/) support, [Eclipse Theia](https://theia-ide.org/) based IDE, [Servo](https://servo.org/) web engine, and more that are coming.
+
+## The Project
+
+The [Oniro Project](https://projects.eclipse.org/projects/oniro) was established through a first-of-its-kind agreement between two major global open-source foundations - The Eclipse Foundation and The OpenAtom Foundation. The collaboration aims to drive the development and global adoption of OpenHarmony. Operating within the framework of the Eclipse Foundation as a dedicated project and [Working Group](https://www.eclipse.org/org/workinggroups/oniro-charter.php), the project leverages the Eclipse Foundation’s extensive experience in open-source governance. This approach fosters transparency and encourages active community participation in the project's development and ongoing evolution.
+
+The project encompasses a diverse array of enhancements, with a particular emphasis on application frameworks, system-level OS components, and integrated development environments (IDE). It also incorporates an advanced toolchain dedicated to ensuring compliance with intellectual property and licensing standards. At its heart, Oniro is committed to providing seamless interoperability, modularization, and an intuitive, visually appealing user interface. As a versatile platform, Oniro offers comprehensive support for a variety of global technologies and applications across multiple sectors, including Consumer Electronics, Home Appliances, Industrial IoT, Smart Home, and Multimedia.
+
+You can learn more about Oniro Project by going to [https://oniroproject.org](https://oniroproject.org).
+
+## The Code
+
+The Oniro code is hosted in GitHub [Eclipse Oniro for OpenHarmony](https://github.com/eclipse-oniro4openharmony) organization. Additionally, the project mirrors all repositories from Gitee [OpenHarmony organization](https://gitee.com/openharmony) to GitHub [Eclipse Oniro Mirrors organization](https://github.com/eclipse-oniro-mirrors). These mirrored repositories are *read-only* and consumed by Eclipse Oniro build system. The mirroring aims to enhance speed and reliability of the repositories' access. Additionally, it simplifies forking and consumption on GitHub. To keep the mirrors current, a synchronization CI workflow runs every 24 hours, updating them with the latest changes.
+
 
 ## Quick Start
 
-As prerequisites git-lfs and repo need to be installed. 100GB of free disk space
-is recommended for the full build.
+To quickly start working with the code and building Oniro please follow our concise [tutorial](quick-build.html). For those interested in experiencing its functionality on actual hardware, as a starting point, we recommend the HiHope HH-SCDAYU200 development kit, which is based on Rockchip's RK3568 processor. This kit is readily accessible in Europe and the USA, offering convenience for developers in these regions.
 
-**To obtain the source code use the following commands:**
+## Chat with Us
 
-```bash
-repo init -u https://github.com/eclipse-oniro4openharmony/manifest.git -b OpenHarmony-3.2-Release --no-repo-verify
-repo sync -c
-repo forall -c 'git lfs pull'
-```
+The Oniro Project engages in community discussions primarily through Eclipse Matrix rooms, and we warmly welcome everyone to join. Whether you seek assistance, wish to contribute, or are keen on interacting with our maintainers, contributors, and community members, the [Oniro Project room](https://matrix.to/#/#oniro-project:matrix.eclipse.org) is the ideal starting point. You can find a full list of Eclipse Oniro chat rooms [here](https://chat.eclipse.org/#/room/#oniro:matrix.eclipse.org). Matrix provides a secure, decentralized communication network, allowing the use of existing accounts from any server. Don’t have a Matrix account? Your [Eclipse Foundation account](https://accounts.eclipse.org/) can seamlessly fulfill this role. Creating an Eclipse Foundation account is a straightforward process, ensuring quick and easy access.
 
-**In the source code directory, fetch the prebuild tools:**
+## Issue Reporting
 
-```bash
-./build/prebuilts_download.sh
-```
-
-**To run the build an isolated docker container is recommended:**
-
-```bash
-docker run -it -v $(pwd):/home/openharmony swr.cn-south-1.myhuaweicloud.com/openharmony-docker/openharmony-docker:1.0.0
-
-```
-
-**In the Docker instance, run the build:**
-
-Select the target device with (e.g.rk3568):
-
-```bash
-hb set
-```
-
-Start the build:
-
-```bash
-hb build
-```
-
+We welcome feedback and issue reports for continuous improvement of the project. If you encounter any problems or bugs, kindly report them on our [GitHub issues page](https://github.com/eclipse-oniro4openharmony/manifest/issues). Your contributions are valuable to the project’s development.

--- a/quick-build.md
+++ b/quick-build.md
@@ -1,0 +1,146 @@
+---
+layout: default
+title: Building Oniro
+parent: Eclipse Oniro Project
+---
+
+# Building Oniro
+
+Before beginning, ensure that [`git-lfs`](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) and [`repo`](https://gerrit.googlesource.com/git-repo) are installed. It is recommended to have at least 100GB of free disk space available for the full build.
+
+## Obtaining the Source Code
+
+To download the source code, execute the following commands in your terminal:
+
+```bash
+repo init -u https://github.com/eclipse-oniro4openharmony/manifest.git -b OpenHarmony-3.2-Release --no-repo-verify
+repo sync -c
+repo forall -c 'git lfs pull'
+```
+
+## Fetching Prebuilt Tools
+
+Once you have the source code run the following script to fetch the prebuilt tools:
+
+```bash
+./build/prebuilts_download.sh
+```
+
+## Setting Up the Build Environment
+
+For building the project, using an isolated Docker container is recommended for a clean and controlled build environment. Run the following command to start the Docker container:
+
+```bash
+docker run -it -v $(pwd):/home/openharmony swr.cn-south-1.myhuaweicloud.com/openharmony-docker/openharmony-docker:1.0.0
+
+```
+
+## Configuring and Starting the Build
+
+Inside the Docker instance, set the target device for the build (e.g. rk3568):
+
+```bash
+hb set
+```
+
+Finally, initiate the build process with:
+
+```bash
+hb build
+```
+
+## Flashing the HiHope HH-SCDAYU200 Development Kit
+
+To begin, connect the board to your computer as outlined in [the HiHope DAYU200 documentation](https://gitee.com/hihope_iot/docs/blob/master/HiHope_DAYU200/docs/%E7%83%A7%E5%BD%95%E6%8C%87%E5%AF%BC%E6%96%87%E6%A1%A3.md). Use the USB-C and mini-USB cables included in the kit to connect to the USB 3.0 OTG port and the mini-USB DEBUG port, respectively.
+
+Power on the device by attaching the power cable. Upon successful connection, your serial console should display output similar to:
+
+```bash
+Bus 002 Device 009: ID 2207:5000 Fuzhou Rockchip Electronics Company "HDC Device"
+...
+Bus 001 Device 069: ID 0403:6001 Future Technology Devices International, Ltd FT232 Serial (UART) IC
+```
+
+Download the `flash.py` flashing tool from [Gitee](https://gitee.com/hihope_iot/docs/tree/master/HiHope_DAYU200/%E7%83%A7%E5%86%99%E5%B7%A5%E5%85%B7%E5%8F%8A%E6%8C%87%E5%8D%97/linux) using the following commands:
+
+```bash
+git clone https://gitee.com/hihope_iot/docs.git hihope_iot_docs
+mkdir flash && cp -r hihope_iot_docs/HiHope_DAYU200/烧写工具及指南/linux/* flash/
+chmod +x flash/flash.py flash/bin/flash.x86_64
+```
+
+To ensure proper device recognition, install the `udev` rule:
+
+```bash
+sudo cp flash/etc/udev/rules.d/85-rk3568.rules /etc/udev/rules.d/85-rk3568.rules
+```
+Then, either reload udev rules or reboot your system:
+
+```bash
+udevadm control --reload-rules
+````
+
+After this setup, running `flash/flash.py -q` should produce the following output, indicating readiness:
+
+```bash
+maskrom
+```
+
+To enable *programming mode* on the device, perform the following steps:
+
+ 1. Press nad hold `VOL/RECOVERY` then `RESET` buttons.
+ 2. Release `RESET` button. 
+  
+Confirm the mode by running `lsusb`, which should show:
+
+```bash
+...
+Bus 001 Device 070: ID 2207:350a Fuzhou Rockchip Electronics Company USB download gadget
+...
+
+$ flash/flash.py -q
+loader
+```
+
+Once the above steps are completed successfully, you can proceed to flash the board:
+
+```bash
+flash/flash.py -a -i ./out/rk3568/packages/phone/images
+```
+
+## Additional Tips and Troubleshooting
+
+### Connecting to serial console
+
+To read the serial output, ensure the board is correctly connected and powered on. The default baud rate for the HH-SCDAYU200 board is 1500000. You can use minicom or a similar serial terminal:
+
+```bash
+minicom -D /dev/ttyUSB0 -b 1500000
+```
+
+### No HDC available in the system
+
+If the `hdc` tool is not available on your host system, build it using the `ohos-sdk`:
+
+```bash
+./build.sh --product-name ohos-sdk --ccache
+```
+
+Find the `hdc` tool in `out/sdk/ohos-sdk/linux/toolchains`. To verify the connection with the device, run:
+
+```bash
+$ hdc list targets
+150100424a544434520325874bb44900
+```
+
+For sending commands to the device:
+
+```bash
+hdc shell
+```
+
+To read hilog output:
+
+```bash
+hdc hilog
+```


### PR DESCRIPTION
1. Add Oniro introductory text.
2. Add basic site hierarchy with index.md and quick-build.md files.
3. Add an external link to Oniro legacy docs.