### PR TITLE
bump build version to OpenHarmony-6.1-Release

### DIFF
--- a/docs/device-development/building-oniro.md
+++ b/docs/device-development/building-oniro.md
@@ -7,7 +7,7 @@ Before beginning, ensure that [`git-lfs`](https://docs.github.com/en/repositorie
 To download the source code, execute the following commands in your terminal:
 
 ```bash
-repo init -u https://github.com/eclipse-oniro4openharmony/manifest.git -b OpenHarmony-6.0-Release -m oniro.xml --no-repo-verify
+repo init -u https://github.com/eclipse-oniro4openharmony/manifest.git -b OpenHarmony-6.1-Release -m oniro.xml --no-repo-verify
 repo sync -c
 repo forall -c 'git lfs pull'
 ```

--- a/docs/device-development/developer-boards/raspberry-pi-4model-b.md
+++ b/docs/device-development/developer-boards/raspberry-pi-4model-b.md
@@ -54,15 +54,14 @@ The Oniro Project supports the Raspberry Pi 4B, and the following features have 
 
 ## Building
 
-After completing the steps in the [quick build documentation](../building-oniro.md) to set up your build environment and obtain the source code for the correct version (ensure you are using the `OpenHarmony-5.0.0-Release` branch), proceed with the following steps to compile and build the system image for the Raspberry Pi 4B.
+After completing the steps in the [quick build documentation](../building-oniro.md) to set up your build environment and obtain the source code for the correct version (ensure you are using the `OpenHarmony-6.1-Release` branch), proceed with the following steps to compile and build the system image for the Raspberry Pi 4B.
 
 ### Step 1: Prepare the Build Environment
 
 Run the following script to apply system patches:
 
 ```bash
-chmod 777 device/board/rpi/system_patch/system_patch.sh
-./device/board/rpi/system_patch/system_patch.sh
+./device/board/rpi/system_patch/do_patch.sh
 ```
 
 ### Step 2: Compile the System Image

--- a/docs/eclipse-oniro-project/openharmony-relationship.md
+++ b/docs/eclipse-oniro-project/openharmony-relationship.md
@@ -21,7 +21,7 @@ different URL in `repo init`, enabling repo sync to pick up the correct reposito
 and revisions from the manifest.
 
 ```bash
-repo init -u https://github.com/eclipse-oniro4openharmony/manifest.git -b OpenHarmony-6.0-Release --no-repo-verify
+repo init -u https://github.com/eclipse-oniro4openharmony/manifest.git -b OpenHarmony-6.1-Release --no-repo-verify
 ```
 
 Creating a new repository is necessary for new add-ons. Once the add-on is


### PR DESCRIPTION
- for the Oniro quick build instruction and for Raspberry Pi build instructions.
- Update instructions for Rpi system patches script.